### PR TITLE
Fix first video explanation link not being clickable

### DIFF
--- a/src/components/reportPage/results-page.css
+++ b/src/components/reportPage/results-page.css
@@ -148,6 +148,12 @@
   .video-result-container {
     flex-direction: row;
     justify-content: center;
+
+    /**
+    This prevents the link from being overlapped by the image result heatmap and not being clickable
+    see https://github.com/Visual-Testing-for-Android-Apps/web/pull/45
+    **/
+    z-index: 1;
   }
 
   .video-result-explanation {


### PR DESCRIPTION
## Proposed changes

### Steps to reproduce
- Upload at least single image and a single video
- Try and click on the first video results "learn more" link

### Expected behaviour
- The link opens
### Actual behaviour
- The link is not selectable

From testing, it looks like the heatmaps canvas "event capture" is overlapping the video result.
If I set the canvas elements position back to default we see that it is overlapping the link.
![image](https://user-images.githubusercontent.com/53201250/131241194-b0c3896d-fae1-48ec-a4dd-c4a3ac9ce64a.png)


The solution is to add a z-index so the link is above the heatmap.
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] DevOps related

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [project guidelines](https://github.com/Visual-Testing-for-Android-Apps/Project-guidelines) doc
- [x] I locally linted my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
